### PR TITLE
Return exceptions in starmap to prevent modal sandbox cancellation

### DIFF
--- a/swebench/harness/modal_eval/run_evaluation_modal.py
+++ b/swebench/harness/modal_eval/run_evaluation_modal.py
@@ -61,6 +61,7 @@ class ModalSandboxRuntime:
         self.sandbox = self._get_sandbox(timeout)
         self.verbose = verbose
         self._stream_tasks = []
+        print(f"Created Modal Sandbox with ID {self.sandbox.object_id} for instance {test_spec.instance_id}")
 
         # Hack for pylint
         self.write_file("/sys/fs/cgroup/cpu/cpu.shares", "2048")

--- a/swebench/harness/modal_eval/run_evaluation_modal.py
+++ b/swebench/harness/modal_eval/run_evaluation_modal.py
@@ -429,12 +429,16 @@ def run_instances_modal(
                         )
                         for test_spec in run_test_specs
                     ],
+                    return_exceptions=True,
                 )
 
                 for result in results:
-                    result = cast(TestOutput, result)
-
+                    if isinstance(result, Exception):
+                        # Since return_exceptions=True, result can be of type Exception
+                        print(f"Error running instance: {result}, skipping.")
+                        continue
                     # Save logs locally
+                    result = cast(TestOutput, result)
                     log_dir = result.log_dir
                     log_dir.mkdir(parents=True, exist_ok=True)
                     with open(log_dir / "run_instance.log", "w") as f:

--- a/swebench/harness/modal_eval/run_evaluation_modal.py
+++ b/swebench/harness/modal_eval/run_evaluation_modal.py
@@ -258,7 +258,7 @@ def run_instance_modal(
     try:
         runner = ModalSandboxRuntime(test_spec=test_spec, timeout=timeout, logger=logger)
     except Exception as e:
-        print(f"Error creating sandbox: {e}")
+        logger.error(f"Error creating sandbox: {e}")
         raise EvaluationError(
             instance_id,
             f"Error creating sandbox: {e}",

--- a/swebench/harness/modal_eval/run_evaluation_modal.py
+++ b/swebench/harness/modal_eval/run_evaluation_modal.py
@@ -10,6 +10,7 @@ import modal.io_streams
 import tenacity
 import time
 import traceback
+from logging import Logger
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -54,14 +55,19 @@ class ModalSandboxRuntime:
     """
 
     def __init__(
-        self, test_spec: TestSpec, timeout: int | None = None, verbose: bool = True
+        self, test_spec: TestSpec, timeout: int | None = None, verbose: bool = True, logger: Logger | None = None
     ):
         self.test_spec = test_spec
         self.image = ModalSandboxRuntime.get_instance_image(test_spec)
         self.sandbox = self._get_sandbox(timeout)
         self.verbose = verbose
         self._stream_tasks = []
-        print(f"Created Modal Sandbox with ID {self.sandbox.object_id} for instance {test_spec.instance_id}")
+        if self.verbose:
+            log_msg = f"Created Modal Sandbox with ID {self.sandbox.object_id} for instance {test_spec.instance_id}"
+            if logger:
+                logger.info(log_msg)
+            else:
+                print(log_msg)
 
         # Hack for pylint
         self.write_file("/sys/fs/cgroup/cpu/cpu.shares", "2048")

--- a/swebench/harness/modal_eval/run_evaluation_modal.py
+++ b/swebench/harness/modal_eval/run_evaluation_modal.py
@@ -256,7 +256,7 @@ def run_instance_modal(
     logger = setup_logger(instance_id, log_file)
 
     try:
-        runner = ModalSandboxRuntime(test_spec, timeout)
+        runner = ModalSandboxRuntime(test_spec=test_spec, timeout=timeout, logger=logger)
     except Exception as e:
         print(f"Error creating sandbox: {e}")
         raise EvaluationError(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
NA


#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
Sets return_exceptions=True for the starmap function on the modal app function to prevent one of the processes exiting cancelling other processes. This is by recommendation of the modal team: https://scale-ext.slack.com/archives/C04PBU6H9GV/p1749923661859989?thread_ts=1749683418.542249&cid=C04PBU6H9GV
#### Any other comments?

<!-- 🧡 Thanks for contributing! -->

Tested while running SWE-bench eval for SWE-bench Verified (gpt 4.1 mini). A patch generated by the model for a specific instance was too large and failing write operations on the modal sandbox, which was causing the main process to exit and the entire swebench eval command to fail.
